### PR TITLE
Update GPIO usage for SDK 2.0 alpha 196

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,11 +2,15 @@ name: Publish package
 on:
   push:
     tags:
-    - 'v*'
+    - 'v[0-9]+.[0-9]+.[0-9]+'
+    - 'v[0-9]+.[0-9]+.[0-9]+-*'
+
+permissions: {}
+
 jobs:
   create-release:
     name: Create new release
     runs-on: ubuntu-latest
     steps:
       - name: Publish
-        uses: toitlang/pkg-publish@v1.0.2
+        uses: toitlang/pkg-publish@v1.5.0

--- a/examples/main.toit
+++ b/examples/main.toit
@@ -2,14 +2,13 @@
 // Use of this source code is governed by a Zero-Clause BSD license that can
 // be found in the EXAMPLES_LICENSE file.
 
-import gpio
 import i2c
 import lsm303dlhc show *
 
 main:
   bus := i2c.Bus
-    --sda=gpio.Pin 21
-    --scl=gpio.Pin 22
+    --sda=21
+    --scl=22
 
   accelerometer := Accelerometer (bus.device Accelerometer.I2C_ADDRESS)
   magnetometer := Magnetometer (bus.device Magnetometer.I2C_ADDRESS)

--- a/package.yaml
+++ b/package.yaml
@@ -1,2 +1,4 @@
 name: lsm303dlhc
 description: Driver for the LSM303DLHC accelerometer and magnetometer.
+environment:
+  sdk: ^2.0.0-alpha.194.1

--- a/package.yaml
+++ b/package.yaml
@@ -1,4 +1,4 @@
 name: lsm303dlhc
 description: Driver for the LSM303DLHC accelerometer and magnetometer.
 environment:
-  sdk: ^2.0.0-alpha.194.1
+  sdk: ^2.0.0-alpha.196


### PR DESCRIPTION
Updates the package for the SDK 2.0.0-alpha.196 peripheral API by passing integer GPIO numbers to peripheral constructors and raising the SDK constraint. It also brings the package publishing workflow up to date where needed.