### PR TITLE
Make sensor reads coherent

### DIFF
--- a/src/accelerometer.toit
+++ b/src/accelerometer.toit
@@ -4,6 +4,7 @@
 
 import serial.device as serial
 import serial.registers as serial
+import io
 import math
 
 /**
@@ -48,6 +49,9 @@ class Accelerometer:
   static OUT_Y_H_A_ ::= 0x2B
   static OUT_Z_L_A_ ::= 0x2C
   static OUT_Z_H_A_ ::= 0x2D
+
+  static BDU_BIT_ ::= 1 << 7
+  static AUTO_INCREMENT_BIT_ ::= 1 << 7
 
   /**
   Standard acceleration due to gravity.
@@ -128,9 +132,10 @@ class Accelerometer:
 
     // 7.1.4. CTRL_REG4_A.
     // Table 27. CTRL_REG4_A description.
-    // Set Block data update to 0. (continuous update).
     // Set Big/little endian data selection to 0. (LSB at lower address).
     reg4_value := 0
+    // Prevent an update while output bytes are being read.
+    reg4_value |= BDU_BIT_
 
     if not 0 <= range < 4: throw "INVALID_RANGE"
     reg4_value |= range << 4
@@ -159,10 +164,10 @@ class Accelerometer:
   The returned values are in in m/s².
   */
   read -> math.Point3f:
-    AUTO_INCREMENT_BIT ::= 0b1000_0000
-    x := reg_.read_i16_le (OUT_X_L_A_ | AUTO_INCREMENT_BIT)
-    y := reg_.read_i16_le (OUT_Y_L_A_ | AUTO_INCREMENT_BIT)
-    z := reg_.read_i16_le (OUT_Z_L_A_ | AUTO_INCREMENT_BIT)
+    raw := read_raw_
+    x := raw[0]
+    y := raw[1]
+    z := raw[2]
 
     // Section 2.1, table3:
     // The linear acceleration sensitivity depends on the range:
@@ -197,3 +202,11 @@ class Accelerometer:
   read_range -> int:
     reg4 := reg_.read_u8 CTRL_REG4_A_
     return (reg4 >> 4) & 0b11
+
+  read_raw_ -> List:
+    bytes := reg_.read_bytes (OUT_X_L_A_ | AUTO_INCREMENT_BIT_) 6
+    return [
+      io.LITTLE_ENDIAN.int16 bytes 0,
+      io.LITTLE_ENDIAN.int16 bytes 2,
+      io.LITTLE_ENDIAN.int16 bytes 4,
+    ]

--- a/src/magnetometer.toit
+++ b/src/magnetometer.toit
@@ -4,6 +4,7 @@
 
 import serial.device as serial
 import serial.registers as serial
+import io
 import math
 
 /**
@@ -117,8 +118,8 @@ class Magnetometer:
   */
   read_temperature -> float:
     // 7.2.9, Table 86.
-    // 12 bit signed integer shifted by 4. In other words: a 16 bit integer with
-    //   the least significant 4 bits not used.
+    // Unlike the LSM303D, the LSM303DLHC stores temperature left-justified.
+    // The value is a left-justified, 12-bit two's complement integer.
     // 8 steps per degree. This means that there are 3 fractional bits.
     // If we just wanted to return an integer temperature value we could
     //   return `value >> 7`.
@@ -135,18 +136,19 @@ class Magnetometer:
     sensor to measure the magnetic field.
   */
   read -> math.Point3f:
-    x := reg_.read_i16_be OUT_X_H_M_
-    z := reg_.read_i16_be OUT_Z_H_M_
-    y := reg_.read_i16_be OUT_Y_H_M_
+    raw := read_raw_
+    x := raw[0]
+    y := raw[1]
+    z := raw[2]
 
     x_converted := x * GAUSS_TO_MICROTESLA_ / gain_xy_
     y_converted := y * GAUSS_TO_MICROTESLA_ / gain_xy_
     z_converted := z * GAUSS_TO_MICROTESLA_ / gain_z_
 
     // Check for saturation.
-    if not -2048 < x < 2047: x_converted = x.sign * float.INFINITY
-    if not -2048 < y < 2047: y_converted = y.sign * float.INFINITY
-    if not -2048 < z < 2047: z_converted = z.sign * float.INFINITY
+    if not -2048 <= x <= 2047: x_converted = x.sign * float.INFINITY
+    if not -2048 <= y <= 2047: y_converted = y.sign * float.INFINITY
+    if not -2048 <= z <= 2047: z_converted = z.sign * float.INFINITY
 
     return math.Point3f
         x_converted
@@ -158,7 +160,12 @@ class Magnetometer:
   */
   read --raw -> List:
     if not raw: throw "INVALID_ARGUMENT"
-    x := reg_.read_i16_be OUT_X_H_M_
-    z := reg_.read_i16_be OUT_Z_H_M_
-    y := reg_.read_i16_be OUT_Y_H_M_
-    return [ x, y, z ]
+    return read_raw_
+
+  read_raw_ -> List:
+    bytes := reg_.read_bytes OUT_X_H_M_ 6
+    return [
+      io.BIG_ENDIAN.int16 bytes 0,
+      io.BIG_ENDIAN.int16 bytes 4,
+      io.BIG_ENDIAN.int16 bytes 2,
+    ]

--- a/tests/driver_test.toit
+++ b/tests/driver_test.toit
@@ -1,0 +1,156 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by an MIT-style license that can be found
+// in the LICENSE file.
+
+import expect show *
+import io
+import serial.device show Device
+import serial.registers show Registers
+
+import lsm303dlhc.accelerometer show Accelerometer
+import lsm303dlhc.magnetometer show Magnetometer
+
+WHO-AM-I ::= 0x0f
+CTRL-REG4-A ::= 0x23
+OUT-X-L-A ::= 0x28
+OUT-X-H-M ::= 0x03
+TEMP-OUT-H-M ::= 0x31
+
+main:
+  test-bdu
+  test-accelerometer-burst
+  test-magnetometer-burst
+  test-temperature
+  test-saturation-boundaries
+
+test-bdu:
+  registers := accelerometer-registers
+  accelerometer := Accelerometer (FakeDevice registers)
+  accelerometer.enable
+  expect-equals 0x80 registers[CTRL-REG4-A]
+
+test-accelerometer-burst:
+  registers := accelerometer-registers
+  accelerometer := Accelerometer (FakeDevice registers)
+  accelerometer.enable
+  registers.set-i16-le OUT-X-L-A (100 << 4)
+  registers.set-i16-le (OUT-X-L-A + 2) (-200 << 4)
+  registers.set-i16-le (OUT-X-L-A + 4) (300 << 4)
+  registers.reset-read-log
+
+  acceleration := accelerometer.read
+  expect-close 0.980665 acceleration.x
+  expect-close -1.96133 acceleration.y
+  expect-close 2.941995 acceleration.z
+  expect-equals 1 registers.read-calls
+  expect-equals 0xa8 registers.last-read-register
+  expect-equals 6 registers.last-read-count
+
+test-magnetometer-burst:
+  registers := magnetometer-registers
+  magnetometer := Magnetometer (FakeDevice registers)
+  registers.set-i16-be OUT-X-H-M 0x1234
+  registers.set-i16-be (OUT-X-H-M + 2) 0x2345  // Z precedes Y in the register map.
+  registers.set-i16-be (OUT-X-H-M + 4) -1_234
+  registers.reset-read-log
+
+  raw := magnetometer.read --raw
+  expect-list-equals [0x1234, -1_234, 0x2345] raw
+  expect-equals 1 registers.read-calls
+  expect-equals OUT-X-H-M registers.last-read-register
+  expect-equals 6 registers.last-read-count
+
+test-temperature:
+  registers := magnetometer-registers
+  magnetometer := Magnetometer (FakeDevice registers)
+
+  // The signed 12-bit value is left-justified; +8 steps is +1 degree.
+  registers.set-i16-be TEMP-OUT-H-M (8 << 4)
+  expect-close 1.0 magnetometer.read-temperature
+
+  registers.set-i16-be TEMP-OUT-H-M (-8 << 4)
+  expect-close -1.0 magnetometer.read-temperature
+
+test-saturation-boundaries:
+  registers := magnetometer-registers
+  magnetometer := Magnetometer (FakeDevice registers)
+  magnetometer.enable
+  registers.set-i16-be OUT-X-H-M -2048
+  registers.set-i16-be (OUT-X-H-M + 2) 0
+  registers.set-i16-be (OUT-X-H-M + 4) 2047
+
+  field := magnetometer.read
+  expect-close (-2048 * 100.0 / 1100) field.x
+  expect-close (2047 * 100.0 / 1100) field.y
+  expect-close 0.0 field.z
+
+  registers.set-i16-be OUT-X-H-M -4096
+  field = magnetometer.read
+  expect-equals -float.INFINITY field.x
+
+expect-close expected/num actual/num:
+  expect (expected - actual).abs < 0.000_001
+
+accelerometer-registers -> FakeRegisters:
+  result := FakeRegisters
+  result[WHO-AM-I] = 0x33
+  return result
+
+magnetometer-registers -> FakeRegisters:
+  result := FakeRegisters
+  result[0x0a] = 0x48
+  result[0x0b] = 0x34
+  result[0x0c] = 0x33
+  return result
+
+class FakeDevice implements Device:
+  registers_/Registers
+
+  constructor .registers_:
+
+  registers -> Registers:
+    return registers_
+
+  read amount/int -> ByteArray:
+    throw "UNIMPLEMENTED"
+
+  write bytes/ByteArray -> none:
+    throw "UNIMPLEMENTED"
+
+class FakeRegisters extends Registers:
+  bytes_/ByteArray := ByteArray 0x80
+  read-calls/int := 0
+  last-read-register/int := -1
+  last-read-count/int := -1
+
+  read-bytes register/int count/int -> ByteArray:
+    read-calls++
+    last-read-register = register
+    last-read-count = count
+    address := register & 0x7f
+    result := ByteArray count
+    count.repeat:
+      result[it] = bytes_[address + it]
+    return result
+
+  write-bytes register/int data/ByteArray -> none:
+    address := register & 0x7f
+    data.size.repeat:
+      bytes_[address + it] = data[it]
+
+  operator [] index/int -> int:
+    return bytes_[index]
+
+  operator []= index/int value/int -> none:
+    bytes_[index] = value
+
+  set-i16-le register/int value/int -> none:
+    io.LITTLE-ENDIAN.put-int16 bytes_ register value
+
+  set-i16-be register/int value/int -> none:
+    io.BIG-ENDIAN.put-int16 bytes_ register value
+
+  reset-read-log:
+    read-calls = 0
+    last-read-register = -1
+    last-read-count = -1

--- a/tests/package.lock
+++ b/tests/package.lock
@@ -1,0 +1,6 @@
+sdk: ^2.0.0-alpha.196
+prefixes:
+  lsm303dlhc: toit-lsm303dlhc
+packages:
+  toit-lsm303dlhc:
+    path: ..

--- a/tests/package.yaml
+++ b/tests/package.yaml
@@ -1,0 +1,3 @@
+dependencies:
+  lsm303dlhc:
+    path: ..


### PR DESCRIPTION
## Summary

- enable accelerometer block data update and read XYZ in one six-byte burst
- read magnetometer XYZ in one coherent burst while preserving the LSM303DLHC X-Z-Y register order
- clarify that temperature is a left-justified signed 12-bit value, unlike the LSM303D
- accept the documented valid magnetometer endpoints instead of treating them as saturation
- add host-side regression coverage for BDU, axis decoding, temperature, saturation boundaries, and transaction shape

## Testing

- `toit analyze` on library sources and example
- `toit analyze driver_test.toit`
- `toit driver_test.toit`
